### PR TITLE
Add Navigator plugin with path filters

### DIFF
--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,4 @@
-displayName=Example
+displayName=Navigator
 author=Nobody
-description=An example greeter plugin
-tags=
-plugins=com.example.ExamplePlugin
+description=Displays paths to selected map locations
+plugins=com.navigator.NavigatorPlugin

--- a/src/main/java/com/navigator/NavigatorConfig.java
+++ b/src/main/java/com/navigator/NavigatorConfig.java
@@ -1,0 +1,39 @@
+package com.navigator;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("navigator")
+public interface NavigatorConfig extends Config
+{
+    @ConfigItem(
+            keyName = "showBanks",
+            name = "Show Banks",
+            description = "Display bank locations"
+    )
+    default boolean showBanks()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "showAnvils",
+            name = "Show Anvils",
+            description = "Display anvil locations"
+    )
+    default boolean showAnvils()
+    {
+        return true;
+    }
+
+    @ConfigItem(
+            keyName = "showFurnaces",
+            name = "Show Furnaces",
+            description = "Display furnace locations"
+    )
+    default boolean showFurnaces()
+    {
+        return true;
+    }
+}

--- a/src/main/java/com/navigator/NavigatorOverlay.java
+++ b/src/main/java/com/navigator/NavigatorOverlay.java
@@ -1,0 +1,41 @@
+package com.navigator;
+
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import javax.inject.Inject;
+import net.runelite.api.Client;
+import net.runelite.client.ui.overlay.Overlay;
+import net.runelite.client.ui.overlay.OverlayLayer;
+import net.runelite.client.ui.overlay.OverlayPosition;
+import net.runelite.client.ui.overlay.OverlayPriority;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.plugins.shortestpath.ShortestPathService;
+
+public class NavigatorOverlay extends Overlay
+{
+    private final Client client;
+    private final NavigatorPlugin plugin;
+    private final ShortestPathService shortestPathService;
+
+    @Inject
+    public NavigatorOverlay(Client client, NavigatorPlugin plugin, ShortestPathService shortestPathService)
+    {
+        this.client = client;
+        this.plugin = plugin;
+        this.shortestPathService = shortestPathService;
+        setPosition(OverlayPosition.DYNAMIC);
+        setLayer(OverlayLayer.ABOVE_SCENE);
+        setPriority(OverlayPriority.MED);
+    }
+
+    @Override
+    public Dimension render(Graphics2D graphics)
+    {
+        WorldPoint target = plugin.getSelectedPoint();
+        if (target != null)
+        {
+            shortestPathService.drawPath(client.getLocalPlayer().getWorldLocation(), target, graphics);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/navigator/NavigatorPanel.java
+++ b/src/main/java/com/navigator/NavigatorPanel.java
@@ -1,0 +1,29 @@
+package com.navigator;
+
+import javax.inject.Inject;
+import javax.swing.JCheckBox;
+import javax.swing.JPanel;
+import net.runelite.client.ui.PluginPanel;
+
+public class NavigatorPanel extends PluginPanel
+{
+    private final JCheckBox bankBox = new JCheckBox("Banks");
+    private final JCheckBox anvilBox = new JCheckBox("Anvils");
+    private final JCheckBox furnaceBox = new JCheckBox("Furnaces");
+
+    @Inject
+    public NavigatorPanel(NavigatorPlugin plugin)
+    {
+        add(bankBox);
+        add(anvilBox);
+        add(furnaceBox);
+
+        bankBox.setSelected(plugin.getConfig().showBanks());
+        anvilBox.setSelected(plugin.getConfig().showAnvils());
+        furnaceBox.setSelected(plugin.getConfig().showFurnaces());
+
+        bankBox.addActionListener(e -> plugin.updateShowBanks(bankBox.isSelected()));
+        anvilBox.addActionListener(e -> plugin.updateShowAnvils(anvilBox.isSelected()));
+        furnaceBox.addActionListener(e -> plugin.updateShowFurnaces(furnaceBox.isSelected()));
+    }
+}

--- a/src/main/java/com/navigator/NavigatorPlugin.java
+++ b/src/main/java/com/navigator/NavigatorPlugin.java
@@ -1,0 +1,87 @@
+package com.navigator;
+
+import com.google.inject.Provides;
+import javax.inject.Inject;
+import lombok.Getter;
+import net.runelite.api.Client;
+import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.shortestpath.ShortestPathService;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.ui.overlay.OverlayManager;
+
+@PluginDescriptor(
+        name = "Navigator"
+)
+public class NavigatorPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private OverlayManager overlayManager;
+
+    @Inject
+    private NavigatorOverlay overlay;
+
+    @Inject
+    private ClientToolbar clientToolbar;
+
+    @Inject
+    private ShortestPathService shortestPathService;
+
+    @Getter
+    @Inject
+    private NavigatorConfig config;
+
+    private NavigationButton navButton;
+
+    private WorldPoint selectedPoint;
+
+    @Provides
+    NavigatorConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(NavigatorConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        overlayManager.add(overlay);
+        navButton = NavigationButton.builder()
+                .tooltip("Navigator")
+                .priority(0)
+                .panel(new NavigatorPanel(this))
+                .build();
+        clientToolbar.addNavigation(navButton);
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        overlayManager.remove(overlay);
+        clientToolbar.removeNavigation(navButton);
+        selectedPoint = null;
+    }
+
+    public void updateShowBanks(boolean value)
+    {
+        // handle updating state
+    }
+
+    public void updateShowAnvils(boolean value)
+    {
+    }
+
+    public void updateShowFurnaces(boolean value)
+    {
+    }
+
+    public WorldPoint getSelectedPoint()
+    {
+        return selectedPoint;
+    }
+}


### PR DESCRIPTION
## Summary
- create Navigator plugin skeleton
- add config with filter toggles for banks, anvils, and furnaces
- overlay uses ShortestPathService
- basic panel UI for filter toggles
- register new plugin in `runelite-plugin.properties`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686b28c7c3a08331ad6a9683c3811804